### PR TITLE
FEATURE: Support recursive types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "wwwision/types": "^1.2",
+        "wwwision/types": "^1.5",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {

--- a/src/Types/DeferredRootLevelDefinition.php
+++ b/src/Types/DeferredRootLevelDefinition.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesGraphQL\Types;
+
+use Closure;
+
+final class DeferredRootLevelDefinition implements RootLevelDefinition
+{
+    private RootLevelDefinition|null $resolvedDefinition = null;
+
+    /**
+     * @param Closure(): RootLevelDefinition $definitionResolver
+     */
+    public function __construct(
+        private readonly Closure $definitionResolver,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->resolve()->getName();
+    }
+
+    public function render(): string
+    {
+        return $this->resolve()->render();
+    }
+
+    public function resolve(): RootLevelDefinition
+    {
+        if ($this->resolvedDefinition === null) {
+            $this->resolvedDefinition = ($this->definitionResolver)();
+        }
+        return $this->resolvedDefinition;
+    }
+}

--- a/src/Types/DeferredRootLevelDefinition.php
+++ b/src/Types/DeferredRootLevelDefinition.php
@@ -14,13 +14,14 @@ final class DeferredRootLevelDefinition implements RootLevelDefinition
      * @param Closure(): RootLevelDefinition $definitionResolver
      */
     public function __construct(
+        private readonly string $name,
         private readonly Closure $definitionResolver,
     ) {
     }
 
     public function getName(): string
     {
-        return $this->resolve()->getName();
+        return $this->name;
     }
 
     public function render(): string

--- a/tests/PHPUnit/GraphQLGeneratorTest.php
+++ b/tests/PHPUnit/GraphQLGeneratorTest.php
@@ -228,6 +228,7 @@ final class GraphQLGeneratorTest extends TestCase
 
             type ClassWithRecursion {
               name: String!
+              self: ClassWithRecursion!
               subClass: SubClassWithRecursion!
             }
 
@@ -268,6 +269,8 @@ final class GraphQLGeneratorTest extends TestCase
             new CustomResolver('SomeOtherShape', 'customWithStringArgument', fn (SomeOtherShape $x, #[Description('Some custom argument description')] string $foo): bool => false),
             new CustomResolver('SomeOtherShape', 'customWithFloatArgument', fn (SomeOtherShape $x, #[Description('Some custom argument description')] float $foo): bool => false),
             new CustomResolver('SomeOtherShape', 'customWithObjectArguments', fn (SomeOtherShape $x, Title $title): Title => $title),
+            new CustomResolver('SomeOtherShape', 'customWithSelfReference', fn (SomeOtherShape $x): SomeOtherShape => $x),
+            new CustomResolver('SomeOtherShape', 'customWithSelfArgument', fn (SomeOtherShape $x, SomeOtherShape $y): bool => true),
         );
         $graphQLSchema = $this->generator->generate(ClassWithQueries::class, $customResolvers);
 
@@ -295,6 +298,8 @@ final class GraphQLGeneratorTest extends TestCase
               customWithStringArgument(foo: String!): Boolean!
               customWithFloatArgument(foo: Float!): Boolean!
               customWithObjectArguments(title: Title!): Title!
+              customWithSelfReference: SomeOtherShape!
+              customWithSelfArgument(y: SomeOtherShapeInput!): Boolean!
             }
 
             GRAPHQL;
@@ -510,6 +515,7 @@ final class ClassWithoutPublicProperties {
 final class ClassWithRecursion {
     public function __construct(
         private readonly string $name, // @phpstan-ignore property.onlyWritten
+        private readonly ClassWithRecursion $self, // @phpstan-ignore property.onlyWritten
         private readonly SubClassWithRecursion $subClass // @phpstan-ignore property.onlyWritten
     ) {}
 }


### PR DESCRIPTION
With this change, schemas with recursive types should not lead to a deadlock any longer.

## Example:

```php
final class SomeClass {
    public function __construct(
        public string $someField,
    ){}

    #[Query]
    public function recursion(): self
    {
    }
}
```

Note: This requires version 1.5.1+ of `wwwision/types` to work!

Fixes: #11